### PR TITLE
오류 수정 & 요약본 페이지 지원

### DIFF
--- a/src/main/java/chat/controller/ChatController.java
+++ b/src/main/java/chat/controller/ChatController.java
@@ -118,4 +118,12 @@ public class ChatController {
 		
 		return dto;
 	}
+	
+	// 업적 1: '모두가 나의 파트너' - 모든 공식 상담사와 채팅
+	@GetMapping("/chat/achieve/partners")
+	public boolean checkAchievePartners(@RequestParam("usercode") int usercode) {
+		int officialCount = chatService.getOfficialCounselorsCountByUser(usercode);
+		
+		return (officialCount >= 6);
+	}
 }

--- a/src/main/java/chat/controller/ChatController.java
+++ b/src/main/java/chat/controller/ChatController.java
@@ -83,29 +83,27 @@ public class ChatController {
 	
 	@GetMapping("/chat/loginfo")
 	public ChatLogPageDto getChatLogInfo(@RequestParam("chatroomcode") Short chatroomcode) {
+		// 해당 chatroom의 정보
+		ChatRoomDto roomDto = chatService.getRoomByCode(chatroomcode);
+		
 		ChatLogPageDto dto = new ChatLogPageDto();
 		// 1. 상담사 이름 받기
 		String counselorname = chatService.getCounselorNameInRoom(chatroomcode);
 		dto.setCounselorname(counselorname);
 		
-		// 목록 받기에 앞서서, 멤버와 각 상담사들의 프로필을 받아온다
-		List<String> speakersPhoto = new ArrayList<>();
-		
+		// 채팅 목록을 받기 앞서서, 사용자와 상담사의 프로필 사진을 각각 받아온다
 		String memberPhoto = chatService.getMemberPhotoInRoom(chatroomcode); // 사용자의 사진
-		List<CounselorDto> counselors = counselorService.getBasicCounselorList(); // 모든 상담사 정보
-		// speaker 0: 사용자의 프로필 사진
-		speakersPhoto.add(memberPhoto);
-		// speaker 1~6: 상담사의 프로필 사진
-		for (CounselorDto cdto: counselors) {
-			speakersPhoto.add(COUNSELOR_PHOTO_PREFIX + cdto.getPhoto());
-		}
+		String counselorPhoto = roomDto.getCounselor().getPhoto() != null? 
+				COUNSELOR_PHOTO_PREFIX + roomDto.getCounselor().getPhoto()
+				: null; // 상담사의 사진
 		
 		// 2. 채팅 목록 받기
 		List<ChatLogDto> chatlog = chatService.selectLog(chatroomcode);
 		List<ChatLogInfoDto> chatLogInfo = new ArrayList<>();
 		for (int i = 0; i < chatlog.size(); i++) {
 			ChatLogInfoDto infoDto = new ChatLogInfoDto();
-			infoDto.setProfilephoto(speakersPhoto.get(chatlog.get(i).getSpeaker()));
+			// 프로필 사진이 상담사/사용자 것인지는 speaker로 분류한다
+			infoDto.setProfilephoto((chatlog.get(i).getSpeaker() > 0)? counselorPhoto : memberPhoto);
 			infoDto.setSpeaker(chatlog.get(i).getSpeaker());
 			infoDto.setContent(chatlog.get(i).getContent());
 			

--- a/src/main/java/chat/controller/ChatController.java
+++ b/src/main/java/chat/controller/ChatController.java
@@ -126,4 +126,12 @@ public class ChatController {
 		
 		return (officialCount >= 6);
 	}
+	
+	// 업적 2: '다섯 번의 토닥' - 채팅 5회 종료
+	@GetMapping("/chat/achieve/fivetodac")
+	public boolean checkAchieveFiveTodac(@RequestParam("usercode") int usercode) {
+		int chatCount = chatService.getChatCountByUser(usercode);
+		
+		return (chatCount >= 5);
+	}
 }

--- a/src/main/java/chat/controller/CounselorController.java
+++ b/src/main/java/chat/controller/CounselorController.java
@@ -30,6 +30,8 @@ public class CounselorController {
 	
 	private String bucketName = "guest-hch";
 	private String folderName = "TODAC/counselors";
+	
+	private String defaultPhotoName = "default_profile_photo_blue.jpg";
 
 	@GetMapping("counselor/list")
 	public List<CounselorDetailInterface> getList(){
@@ -43,8 +45,8 @@ public class CounselorController {
 	
 	@PostMapping("counselor/custom")
 	public void insertCounselor(@ModelAttribute CounselorCustomDto dto, @RequestParam(value = "upload", required = false) MultipartFile upload) {
-		// 1. 이미지 파일 업로드하여 이름 얻기 - 이미지가 없으면 null로 남긴다
-		String photoName = null;
+		// 1. 이미지 파일 업로드하여 이름 얻기 - 이미지가 없으면 기본 이미지 이름으로 남긴다
+		String photoName = defaultPhotoName;
 		if (upload != null)
 			photoName = storageService.uploadFile(bucketName, folderName, upload);
 		
@@ -71,8 +73,8 @@ public class CounselorController {
 		CounselorDto dto = counselorService.getCounselorByCode(counselorcode);
 		// 파일 이름 받기
 		String photo = dto.getPhoto();
-		// 파일이 존재하면, 스토리지에서 이를 먼저 삭제해준다
-		if (photo != null) {
+		// 파일이 디폴트가 아닌 다른 이미지라면, 스토리지에서 이를 먼저 삭제해준다
+		if (!photo.equals(defaultPhotoName)) {
 			storageService.deleteFile(bucketName, folderName, photo);
 		}
 		

--- a/src/main/java/chat/repository/ChatDao.java
+++ b/src/main/java/chat/repository/ChatDao.java
@@ -83,4 +83,8 @@ public class ChatDao {
 	public int getOfficialCounselorsCountByUser(int usercode) {
 		return roomRepository.getOfficialCounselorsCountByUser(usercode);
 	}
+	
+	public int getChatCountByUser(int usercode) {
+		return roomRepository.getChatCountByUser(usercode);
+	}
 }

--- a/src/main/java/chat/repository/ChatDao.java
+++ b/src/main/java/chat/repository/ChatDao.java
@@ -78,4 +78,9 @@ public class ChatDao {
 	public String getMemberUsercodeInRoom(Short chatroomcode) {
 		return roomRepository.getMemberUsercodeInRoom(chatroomcode);
 	}
+	
+	// 업적
+	public int getOfficialCounselorsCountByUser(int usercode) {
+		return roomRepository.getOfficialCounselorsCountByUser(usercode);
+	}
 }

--- a/src/main/java/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/chat/repository/ChatRoomRepository.java
@@ -59,4 +59,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoomDto, Short> {
 			where r.usercode = :usercode and m.type = 'admin';
 			""", nativeQuery = true)
 	public int getOfficialCounselorsCountByUser(@Param("usercode") int usercode);
+	
+	@Query(value = "select count(*) from chatroom where usercode = :usercode", nativeQuery = true)
+	public int getChatCountByUser(@Param("usercode") int usercode);
 }

--- a/src/main/java/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/chat/repository/ChatRoomRepository.java
@@ -49,4 +49,14 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoomDto, Short> {
 			, nativeQuery = true)
 	public String getMemberUsercodeInRoom(@Param("chatroomcode") Short chatroomcode);
 	
+	// 업적 관련
+	@Query(value = 
+			"""
+			select count(distinct r.counselorcode)
+			from chatroom r
+			left join counselor c on r.counselorcode = c.counselorcode
+			left join member m on c.usercode = m.usercode
+			where r.usercode = :usercode and m.type = 'admin';
+			""", nativeQuery = true)
+	public int getOfficialCounselorsCountByUser(@Param("usercode") int usercode);
 }

--- a/src/main/java/chat/service/ChatService.java
+++ b/src/main/java/chat/service/ChatService.java
@@ -60,4 +60,8 @@ public class ChatService {
 	public int getOfficialCounselorsCountByUser(int usercode) {
 		return chatDao.getOfficialCounselorsCountByUser(usercode);
 	}
+	
+	public int getChatCountByUser(int usercode) {
+		return chatDao.getChatCountByUser(usercode);
+	}
 }

--- a/src/main/java/chat/service/ChatService.java
+++ b/src/main/java/chat/service/ChatService.java
@@ -55,4 +55,9 @@ public class ChatService {
 	public String getMemberUsercodeInRoom(Short chatroomcode) {
 		return chatDao.getMemberUsercodeInRoom(chatroomcode);
 	}
+	
+	// 업적
+	public int getOfficialCounselorsCountByUser(int usercode) {
+		return chatDao.getOfficialCounselorsCountByUser(usercode);
+	}
 }

--- a/src/main/reactjs/src/components/chat/chattingroom/ChatRoomMain.js
+++ b/src/main/reactjs/src/components/chat/chattingroom/ChatRoomMain.js
@@ -22,9 +22,13 @@ const ReactSwal = withReactContent(Swal);
 const STORAGE_PHOTO_BASE = 'https://kr.object.ncloudstorage.com/guest-hch/TODAC/';
 const STORAGE_COUNSELOR_FOLDER_NAME = 'counselors/';
 
+const BADGE_NAME_PARTNERS = "모두가 나의 파트너";
+const BADGE_NAME_FIVETODAC = "다섯 번의 토닥";
+
 const ChatRoomMain = () => {
     const [query, setQuery] = useSearchParams();
     const counselorcode = query.get("counselorcode");
+    const usercode = sessionStorage.getItem("usercode");
 
     const [log, setLog] = useState([]);
     const [input, setInput] = useState('');
@@ -135,6 +139,21 @@ const ChatRoomMain = () => {
                 data: JSON.stringify(logData),
                 headers: { 'Content-Type': 'application/json' }
             });
+
+            // chatroom 적용 뒤, 업적 처리
+
+            // 1. '모두가 나의 파트너': 모든 상담사와 1회 이상 상담
+            let badgeResponse = await axios.get("/chat/achieve/partners?usercode=" + usercode);
+            console.log(badgeResponse);
+            if (badgeResponse.data) {
+                // 업적 달성 처리 시도
+                let achieveResult = await axios.post(`/badgeinsert?usercode=${usercode}&achievename=${BADGE_NAME_PARTNERS}`)
+                console.log(achieveResult);
+
+                if (achieveResult.data) {
+                    await popupAchievement(BADGE_NAME_PARTNERS);
+                }
+            }
 
             ReactSwal.fire({
                 icon: 'success',

--- a/src/main/reactjs/src/components/chat/chattingroom/ChatRoomMain.js
+++ b/src/main/reactjs/src/components/chat/chattingroom/ChatRoomMain.js
@@ -143,15 +143,24 @@ const ChatRoomMain = () => {
             // chatroom 적용 뒤, 업적 처리
 
             // 1. '모두가 나의 파트너': 모든 상담사와 1회 이상 상담
-            let badgeResponse = await axios.get("/chat/achieve/partners?usercode=" + usercode);
-            console.log(badgeResponse);
-            if (badgeResponse.data) {
+            let badgeResponsePartner = await axios.get("/chat/achieve/partners?usercode=" + usercode);
+            if (badgeResponsePartner.data) {
                 // 업적 달성 처리 시도
-                let achieveResult = await axios.post(`/badgeinsert?usercode=${usercode}&achievename=${BADGE_NAME_PARTNERS}`)
-                console.log(achieveResult);
+                let achieveResult = await axios.post(`/badgeinsert?usercode=${usercode}&achievename=${BADGE_NAME_PARTNERS}`);
 
                 if (achieveResult.data) {
                     await popupAchievement(BADGE_NAME_PARTNERS);
+                }
+            }
+
+            // 2. '다섯 번의 토닥': 채팅 5회 이상 종료
+            let badgeResponseFive = await axios.get("/chat/achieve/fivetodac?usercode=" + usercode);
+            if (badgeResponseFive.data) {
+                // 업적 달성 처리 시도
+                let achieveResult = await axios.post(`/badgeinsert?usercode=${usercode}&achievename=${BADGE_NAME_FIVETODAC}`);
+
+                if (achieveResult.data) {
+                    await popupAchievement(BADGE_NAME_FIVETODAC);
                 }
             }
 

--- a/src/main/reactjs/src/components/chat/document/ChatSummary.js
+++ b/src/main/reactjs/src/components/chat/document/ChatSummary.js
@@ -18,6 +18,7 @@ const ChatSummary = () => {
     const roomcode = query.get("roomcode");
     const [loading, setLoading] = useState(true); // 요약본 생성 중인지 여부
     const [summarizedMessages, setSummarizedMessages] = useState({ summarizedUserMessage: "", summarizedCounselorMessage: "" });
+    const [hasDiagnosis, setHasDiagnosis] = useState(false);
 
     // 포인트 사용
     const [donationAmount, setDonationAmount] = useState(500);
@@ -212,6 +213,10 @@ const ChatSummary = () => {
 
         // 이 함수는 말그대로, 지금 만든 요약본을 DB에 집어넣는 작업만 하도록 하자.
         checkData();
+        axios.get("/chat/diagnosis/check?chatroomcode=" + roomcode)
+            .then((res) => {
+                setHasDiagnosis(res.data ? true : false);
+            })
     }, []);
 
     return (
@@ -232,8 +237,16 @@ const ChatSummary = () => {
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <button className='white long' onClick={() => nav('../../')}>마이 홈 이동하기</button>
                 <div style={{ position: 'relative' }}>
-                    <span role="img" aria-label="info-icon" className="info-icon" style={{ cursor: 'pointer', position: 'absolute', top: 3.5, right: -24 }} onClick={handleInfoClick}><img src={info} alt='Info Image' style={{ width: '20px', height: '20px' }} /></span>
-                    <button className='deepblue long' onClick={goDiagnosis}>진단서 발급(500P)</button>
+                    {
+                        (hasDiagnosis) ?
+                            <button className='deepblue long' onClick={goDiagnosis}>나의 진단서 확인</button>
+                            :
+                            <span>
+                                <span role="img" aria-label="info-icon" className="info-icon" style={{ cursor: 'pointer', position: 'absolute', top: 3.5, right: -24 }} onClick={handleInfoClick}><img src={info} alt='Info Image' style={{ width: '20px', height: '20px' }} /></span>
+                                <button className='deepblue long' onClick={goDiagnosis}>진단서 발급(500P)</button>
+                            </span>
+                    }
+
                 </div>
             </div>
         </div >


### PR DESCRIPTION
1. 오류: 커스텀 상담사와의 상담 일지를 볼 수 없던 현상 수정
2. 요약본 페이지에서 진단서 발급 여부에 따라 버튼이 다르게 출력되도록 구현
3. 상담사 커스텀 시 이미지가 없으면 디폴트 이미지로 DB에 저장되도록 개선
4. 다음 업적 달성 구현: '모두가 나의 파트너', '다섯 번의 토닥'
('신생 상담사'의 경우, 뱃지가 준비되면 그 때 구현하겠습니다)