### PR TITLE
상담 - 일부 수정

### DIFF
--- a/src/main/reactjs/src/components/chat/chattingroom/ChatRoomMidBar.js
+++ b/src/main/reactjs/src/components/chat/chattingroom/ChatRoomMidBar.js
@@ -4,7 +4,7 @@ import React from 'react';
 const ChatRoomMidBar = ({ counselorname, handleFinishChat }) => {
     return (
         <div className='fs_18 fw_600 mt_10 chatmid'>
-            <div>
+            <div className='chatmid-title'>
                 <span className='fs_19 col_blue2'>{counselorname ? counselorname : '어느'}</span> 상담사와 마음 공유중...
             </div>
             <button type='button' className='deepblue'

--- a/src/main/reactjs/src/components/chat/chattingroom/ChatRoomStyle.css
+++ b/src/main/reactjs/src/components/chat/chattingroom/ChatRoomStyle.css
@@ -9,10 +9,13 @@ div.chatheader {
 }
 
 div.chatmid {
-    height: 35px;
     display: flex;
     justify-content: space-between;
     align-items: center;
+}
+
+div.chatmid div.chatmid-title {
+    flex: 1;
 }
 
 div.chatcontent {

--- a/src/main/reactjs/src/components/chat/counselor/CounselorStyle.css
+++ b/src/main/reactjs/src/components/chat/counselor/CounselorStyle.css
@@ -45,6 +45,7 @@ div.counselorcard img.counselorphoto.backphoto {
 div.counselorcard img.counselorphoto.frontphoto {
     width: 80%;
     height: auto;
+    max-height: 200px;
 }
 
 div.counselbtndiv {

--- a/src/main/reactjs/src/components/chat/counselorcustom/create/CounselorCreateTable.js
+++ b/src/main/reactjs/src/components/chat/counselorcustom/create/CounselorCreateTable.js
@@ -20,6 +20,9 @@ const CounselorCreateTable = () => {
         'greeting': 50
     };
 
+    // 파일의 최대 크기 : 3MB (413 error 방지를 위함)
+    const PHOTO_MAX_SIZE = 1024 * 1024 * 3;
+
     const nav = useNavigate();
 
     // 앞서 상담사 선택에서 받는 형태의 데이터 구조를 가지게 한다.
@@ -53,23 +56,35 @@ const CounselorCreateTable = () => {
 
     // 사진 변경 이벤트
     const handlePhotoUpload = (e) => {
-        console.log(e.target.files);
         const file = e.target.files[0];
         if (file) {
-            if (file.type.startsWith('image/')) {
-                setPhotoFile(file);
-                // 미리보기를 위한 이미지 URL 저장
-                setData({ ...data, photo: URL.createObjectURL(file) });
-            }
-            else {
+            // 이미지가 아닌 경우
+            if (!file.type.startsWith('image/')) {
                 ReactSwal.fire({
                     icon: 'error',
                     title: '이미지만 업로드 가능!',
                     html: '이미지 파일만 업로드 해주세요.',
                     confirmButtonColor: '#5279FD',
                     confirmButtonText: '확인'
-                })
+                });
+                return;
             }
+
+            // 크기를 넘어간 경우
+            if (file.size > PHOTO_MAX_SIZE) {
+                ReactSwal.fire({
+                    icon: 'error',
+                    title: '파일 크기 초과!',
+                    html: '파일의 크기는 3MB를 초과할 수 없습니다.',
+                    confirmButtonColor: '#5279FD',
+                    confirmButtonText: '확인'
+                });
+                return;
+            }
+
+            setPhotoFile(file);
+            // 미리보기를 위한 이미지 URL 저장
+            setData({ ...data, photo: URL.createObjectURL(file) });
         }
     }
 
@@ -194,11 +209,17 @@ const CounselorCreateTable = () => {
                     <tr>
                         <td className='tablehead'>사진</td>
                         <td style={{ position: 'relative' }}>
-                            <img alt='' src={data.photo ? data.photo : defaultImage} style={{ width: '100%', height: 'auto' }} />
-                            <input type='file' accept='image/*' id='counselor-create-image' style={{ display: 'none' }}
-                                onChange={handlePhotoUpload} />
-                            <img style={{ width: '30px', height: "30px", position: 'absolute', bottom: "10px", right: '10px' }} className="img-fluid"
-                                alt='이미지변경' src={cameraIcon} onClick={() => document.getElementById("counselor-create-image").click()} />
+                            <div style={{ position: 'relative' }}>
+                                <img alt='' src={data.photo ? data.photo : defaultImage} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+                                <input type='file' accept='image/*' size={PHOTO_MAX_SIZE} id='counselor-create-image' style={{ display: 'none' }}
+                                    onChange={handlePhotoUpload} />
+                                <img style={{ width: '30px', height: "30px", position: 'absolute', bottom: "5px", right: '5px' }} className="img-fluid"
+                                    alt='이미지변경' src={cameraIcon} onClick={() => document.getElementById("counselor-create-image").click()} />
+                            </div>
+                            <br />
+                            <div className='explain'>
+                                * 파일은 이미지만 가능하며, 최대 3MB의 사진만 업로드 가능합니다.
+                            </div>
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
1. 상담사 커스텀 - 사진의 크기에 height: 100%, object-fit: cover 부여하여, 일부 환경(Safari 등)에서 height가 지나치게 커지는 현상 수정 시도
2. 상담사 커스텀 - 파일의 크기가 3MB를 넘지 않도록 수정 (413 error 방지)
3. 상담사 카드 - 앞면에 들어가는 이미지의 크기가 최대 200px를 넘지 않도록 수정
4. 채팅창 - '마음 공유중...' 텍스트가 2줄이 되면 버튼도 2줄이 되던 현상 수정