### PR TITLE
상담 - 일부 수정

### DIFF
--- a/src/main/reactjs/src/components/chat/ChatMain.js
+++ b/src/main/reactjs/src/components/chat/ChatMain.js
@@ -45,7 +45,7 @@ const ChatMain = () => {
 
     const handleCounselorDelete = async (data) => {
         const userConfirm = await ReactSwal.fire({
-            icon: 'question',
+            icon: 'warning',
             title: '정말로 삭제하시겠어요?',
             html: <div>삭제된 상담사는 복구할 수 없습니다.<br />정말로 <span className='col_red fs_20 fw_600'>{data.name}</span> 상담사를 삭제할까요?</div>,
             confirmButtonText: '예',

--- a/src/main/reactjs/src/components/chat/counselor/CounselorCardBack.js
+++ b/src/main/reactjs/src/components/chat/counselor/CounselorCardBack.js
@@ -43,6 +43,7 @@ const CounselorCardBack = ({ borcolor, data, handleCounselClick, handleCounselor
             </div>
             <div className='mt_10 counsel-start'>
                 <button type='button' className='counselinnerbtn officialbtn btn-jittery fw_600'
+                    style={{ backfaceVisibility: 'hidden', WebkitBackfaceVisibility: 'hidden' }}
                     onClick={() => handleCounselClick(data)}>상담 시작!</button>
             </div>
         </div>

--- a/src/main/reactjs/src/components/chat/counselorcustom/create/CounselorCreateTable.js
+++ b/src/main/reactjs/src/components/chat/counselorcustom/create/CounselorCreateTable.js
@@ -237,12 +237,11 @@ const CounselorCreateTable = () => {
                         <td>
                             <input className='input_text' style={{ width: '160px' }}
                                 type="text" name="personality" value={data.personality} maxLength={INPUT_MAX_LENGTH['personality']} required
-                                ref={inputPersonality}
+                                ref={inputPersonality} placeholder='ex) 얼음처럼 냉철한'
                                 onChange={handleInputChange} />&nbsp;상담사<br />
                             <span className='custom-inputlen'>({data.personality.length} / {INPUT_MAX_LENGTH['personality']})</span><br /><br />
                             <div className='explain'>
-                                * '~한', '~인'과 같은 형태로 작성하셔야 원하는 대로 동작할 거에요!<br />
-                                ex{')'} 얼음처럼 냉철한
+                                * '~한', '~인'과 같은 형태로 작성하셔야 원하는 대로 동작할 거에요!
                             </div>
                         </td>
                     </tr>


### PR DESCRIPTION
1. 상담사 삭제 - 아이콘을 warning으로 수정
2. 상담사 선택 - 카드 뒷면의 버튼에 backface-visibility 속성 직접 부여 시도
3. 상담사 커스텀 폼 - '성격' 입력에서 설명의 예시 부분을 placeholder로 이동